### PR TITLE
Fix warnings that String.strip/2 is deprecated

### DIFF
--- a/lib/redix_cluster/pools.ex
+++ b/lib/redix_cluster/pools.ex
@@ -16,14 +16,14 @@ defmodule RedixCluster.Pools.Supervisor do
 
   def init(nil), do: {:ok, {{:one_for_one, 1, 5}, []}}
 
-  @spec new_pool(char_list, integer) :: {:ok, atom}|{:error, atom}
+  @spec new_pool(charlist, integer) :: {:ok, atom}|{:error, atom}
   def new_pool(host, port) do
     pool_name = ["Pool", host, ":", port] |> Enum.join |> String.to_atom
     case Process.whereis(pool_name) do
       nil ->
         :ets.insert(__MODULE__, {pool_name,0})
         pool_size = get_env(:pool_size, @default_pool_size)
-       	pool_max_overflow = get_env(:pool_max_overflow, @default_pool_max_overflow)
+        pool_max_overflow = get_env(:pool_max_overflow, @default_pool_max_overflow)
         pool_args = [name: {:local, pool_name},
                      worker_module: RedixCluster.Worker,
                      size: pool_size,

--- a/lib/redix_cluster/run.ex
+++ b/lib/redix_cluster/run.ex
@@ -62,8 +62,8 @@ defmodule RedixCluster.Run do
       nil -> RedixCluster.Hash.hash(key)
       [tohash_key] ->
         tohash_key
-          |> String.strip(?{)
-          |> String.strip(?})
+          |> String.trim("{")
+          |> String.trim("}")
           |> RedixCluster.Hash.hash
     end
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
-%{"benchfella": {:git, "https://github.com/alco/benchfella.git", "abed12d37022012133da51b4acbbf07bd61dab32", []},
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+%{
+  "benchfella": {:git, "https://github.com/alco/benchfella.git", "abed12d37022012133da51b4acbbf07bd61dab32", []},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "crc": {:hex, :crc, "0.5.2", "6db0c06f4bb2ae6a737a32b31fd40842774d4aae903b76e5f4dae44bd4b2742c", [:make, :mix], [], "hexpm"},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], [], "hexpm"},
   "dogma": {:hex, :dogma, "0.1.13", "7b6c6ad2b3ee6501eda3bd39e197dd5198be8d520d1c175c7f713803683cf27a", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
@@ -8,5 +9,6 @@
   "espec": {:git, "https://github.com/antonmi/espec.git", "a73b0067fac8b197533b514ac38c98f0795a024a", []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
-  "redix": {:hex, :redix, "0.7.0", "14a22cba1137600ccf8d64baf1b291689add779488f9a193d7d83dcc3e03a7a4", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"}}
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "redix": {:hex, :redix, "0.7.0", "14a22cba1137600ccf8d64baf1b291689add779488f9a193d7d83dcc3e03a7a4", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
Fix below warnings.

- `String.strip/2 is deprecated, use String.trim/2 with a binary second argument`
- `the char_list() type is deprecated, use charlist()`