### PR TITLE
included applicationsを使わないようにする

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,6 @@ defmodule RedixCluster.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [mod: {RedixCluster, []},
-    included_applications: [:crc],
     extra_applications: [:logger]]
   end
 


### PR DESCRIPTION
elixir 1.9で追加された `mix release` で、 `included_applications` と `applications` に同じアプリケーションを指定することができない。
https://github.com/elixir-lang/elixir/issues/9163

このライブラリのユーザーが `crc` を使っていた場合に発生する。
```
** (Mix) :crc is listed both as a regular application and as an included application
```

`included_applications` に指定する特別な理由もなさそうなので `applications` に移すことで回避する。 `applications` は明示的に指定していないが、elixir 1.4以上ではdepsから推論してくれるので問題ない。
https://github.com/xflagstudio/redix-cluster/blob/b42d8643f9f2bcd045d4d8f3648fb434b72240e8/mix.exs#L7

参考:
https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/ のApplication inference